### PR TITLE
Fix plugin version (0.1.0 -> 0.3.0)

### DIFF
--- a/tmsforkorea/__init__.py
+++ b/tmsforkorea/__init__.py
@@ -37,7 +37,7 @@ def description():
     return "Daum, Naver layers"
   
 def version():
-    return "0.1.0"
+    return "0.3.0"
   
 def qgisMinimumVersion():
     return "1.8"


### PR DESCRIPTION
플러그인 버전이 `metadata.txt`에서는 0.3.0으로 올라갔는데 `__init__.py`에는 0.1.0으로 남아 있어서 업그레이드 문구가 매번 표시되고 있었습니다. `__init__.py`의 버전을 변경해서 올립니다.
